### PR TITLE
Focus state same as hover .form-css

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -99,7 +99,8 @@ button:hover {
 .form-css::-ms-expand {
 	display: none;
 }
-.form-css:hover {
+.form-css:hover,
+.form-css:focus {
 	border-color: #888;
 	border: 1px solid #BFBFBF;
 	background-color: white;


### PR DESCRIPTION
This removes the blue glow in :focus state of the .form-css textarea and any other input that has the form-css class. Styles from bootstrap .form-css are replaced by styles regarding blue glow.

Related https://github.com/mikkokotila/Padma/issues/1