### PR TITLE
Add 404 aborts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,8 +27,8 @@ from app import routes
 
 # below is for debugging only
 
-#app.jinja_env.auto_reload = True
-#app.config['TEMPLATES_AUTO_RELOAD'] = True
+app.jinja_env.auto_reload = True
+app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 # try first docker, then gunicorn, and
 # then flask if all else fails. Handle 

--- a/app/models/find_similar.py
+++ b/app/models/find_similar.py
@@ -19,6 +19,7 @@ def find_similar(request, dictionary):
 def similar_words(word, dictionary):
     
     import pandas as pd
+    from flask import abort
 
     from ..utils.stopword import stopword_english
 
@@ -29,6 +30,10 @@ def similar_words(word, dictionary):
         word = word + '་'
 
     temp = pd.Series(dictionary[dictionary.word == word]['meaning'])
+    
+    if len(temp) == 0:
+        abort(404)
+    
     temp = temp.str.cat().split()
     temp = pd.Series(temp)
     temp = temp.str.replace('[+-;:{}\[\],.«»]',' ')

--- a/app/models/render_text.py
+++ b/app/models/render_text.py
@@ -5,16 +5,32 @@ def render_text(request, texts):
     texts | dict | body of texts loaded in Padma
     '''
 
+    from flask import abort
+
     title = request.args.get('title')
     start = request.args.get('start')
     end = request.args.get('end')
 
-    text = ''.join(texts[title]['text']).split()
+    try:
+        text = ''.join(texts[title]['text']).split()
+    except KeyError:
+        abort(404)
 
-    if start is None:
+    if start == '':
         start = 0
-    if end is None:
-        end = len(text)
+
+    if end == '':
+        end = int(start) + 10000
+
+    try:
+        int(start)
+    except:
+        abort(404)
+
+    try:
+        int(end)
+    except:
+        abort(404)
 
     text = ''.join(text[int(start):int(end)])
 

--- a/app/models/search_texts.py
+++ b/app/models/search_texts.py
@@ -6,6 +6,7 @@ def search_texts(request, texts):
     '''
 
     from flask import render_template
+    from flask import abort
 
     from ..utils.tokenization import tokenization
 
@@ -14,7 +15,13 @@ def search_texts(request, texts):
     if query is None:
         query = request.form['query']
 
+    if len(query) == 0:
+        abort(404)
+
     results = _search_texts(query, texts)
+
+    if len(results) == 0:
+        abort(404)
 
     data = {'query': query,
             'text': [i[0] for i in results],

--- a/app/models/tokenize.py
+++ b/app/models/tokenize.py
@@ -1,11 +1,16 @@
 def tokenize(request):
 
     from flask import render_template
+    from flask import abort
+
     from ..utils.tokenization import tokenization
 
     text = request.args.get('query')
 
     tokens = tokenization(text)
+
+    if len(tokens) == 0:
+        abort(404)
 
     data = {'tokens': tokens}
 

--- a/app/models/word_statistics.py
+++ b/app/models/word_statistics.py
@@ -105,6 +105,7 @@ def _word_statistics(word, filenames, mode='prominence'):
     
     '''Returns various text statistics.'''
 
+    from flask import abort
     import signs
     import re
     
@@ -121,6 +122,9 @@ def _word_statistics(word, filenames, mode='prominence'):
         if mode == 'most_common':
             out += _most_common(filename, word, span=1)
             
+    if len(out) == 0:
+        abort(404)
+
     if mode == 'co_occurance':
         describe = signs.Describe(out)
         return describe.get_counts()


### PR DESCRIPTION
Regardless of the underlying error, API end-points will always return 404. So any formatting issue, missing value, and everything else, 404. cc @blahmonkey 